### PR TITLE
Put the signatures after the line number

### DIFF
--- a/bin/tags.dart
+++ b/bin/tags.dart
@@ -115,10 +115,10 @@ class Ctags {
               path.relative(file.path, from: root),
               '/${constructor.matchAsPrefix(member.toSource())[0]}/;"',
               'M',
-              'class:${declaration.name}',
               options['line-numbers'] as bool
                   ? 'line:${unit.lineInfo.getLocation(member.offset).lineNumber}'
-                  : ''
+                  : '',
+              'class:${declaration.name}'
             ]);
           } else if (member is FieldDeclaration) {
             member.fields.variables.forEach((variable) {
@@ -127,10 +127,10 @@ class Ctags {
                 path.relative(file.path, from: root),
                 '/${member.toSource()}/;"',
                 'i',
-                'class:${declaration.name}',
                 options['line-numbers'] as bool
                     ? 'line:${unit.lineInfo.getLocation(member.offset).lineNumber}'
-                    : ''
+                    : '',
+                'class:${declaration.name}'
               ]);
             });
           } else if (member is MethodDeclaration) {
@@ -139,10 +139,10 @@ class Ctags {
               path.relative(file.path, from: root),
               '/${method.matchAsPrefix(member.toSource())[0]}/;"',
               member.isStatic ? 'M' : 'm',
-              'class:${declaration.name}',
               options['line-numbers'] as bool
                   ? 'line:${unit.lineInfo.getLocation(member.offset).lineNumber}'
-                  : ''
+                  : '',
+              'class:${declaration.name}'
             ]);
           }
         });


### PR DESCRIPTION
The [universal-ctags](https://github.com/universal-ctags/ctags) standard is to put the token's signature (the annotations you're outputting with `class:${declaration.name}`) **after** the line number.

It matters because some parsers are expecting the line number to be at that exact position (i.e. at the 5th position, separated by tabs). From my observation, the default order is:

`name[1] filepath[2] regex[3] symbol_letter[4] LINE_NR[5] ...`