### PR TITLE
[FIX] authorize null safety

### DIFF
--- a/bin/tags.dart
+++ b/bin/tags.dart
@@ -7,6 +7,9 @@ import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/analysis/utilities.dart' as an;
 import 'package:path/path.dart' as path;
 import 'package:args/args.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+
 
 class Ctags {
   ArgResults options;
@@ -115,7 +118,7 @@ class Ctags {
     CompilationUnit unit;
     try {
       result =
-          an.parseFile(path: file.path, featureSet: FeatureSet.fromEnableFlags([]));
+          an.parseFile(path: file.path, featureSet: FeatureSet.fromEnableFlags2(sdkLanguageVersion: Version(2, 10, 0), flags: ['non-nullable']));
       unit = result.unit;
     } catch (e) {
       print('ERROR: unable to generate tags for ${file.path}');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 executables:
     dart_ctags: tags
 dependencies:
-    analyzer: ^0.40.0
+    analyzer: ^2.0.0
     path: ^1.7.0
     quiver: ^2.1.3
     args: ^1.6.0


### PR DESCRIPTION
If I tried to generate a tags file for a file who contains a **sound null safety**, I get the following message
```
ERROR: unable to generate tags for --pathOfTheFile--
```
The error comes from the *analyzer* package which does not allow `null-safety`